### PR TITLE
Add rust-toolchain configuration

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.79"


### PR DESCRIPTION
Introduce a configuration file to specify the Rust toolchain version as 1.79.